### PR TITLE
chore: bump to v0.21.16rc1, sync packages

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -1,7 +1,7 @@
 {
     "dev": {
-        "agent/valory/mech_server/0.1.0": "bafybeidgekjvls4zxzvpqnzcgawpu5whi5va4yvwpzsqinahdoaefw3hbi",
-        "service/valory/mech_server/0.1.0": "bafybeicf53d2zqehy7ynb476dhoseb5mqym4egoe76jbpbabkkwn2pp5zy"
+        "agent/valory/mech_server/0.1.0": "bafybeibtep6cwo3vg77vrnowilksnuq5lsf5mclzji3hkuw6l26sl7ndrm",
+        "service/valory/mech_server/0.1.0": "bafybeig7m2o5hi3qwbabmlfhze7ghjn23lew54bkvujkhm6go24ousk7eu"
     },
     "third_party": {
         "protocol/valory/acn_data_share/0.1.0": "bafybeieqisfr6lhaaesq37lk7vyaxza2h6nucshksgyo2djqfyf2saqo4i",
@@ -17,31 +17,31 @@
         "contract/valory/complementary_service_metadata/0.1.0": "bafybeibjk5gdgc54wx5bz4fl2666urmfj6mx3ocqxyumqpj7wq5fdg4diu",
         "contract/valory/hash_checkpoint/0.1.0": "bafybeihpds2kkr5okehfa4ohbalur3fihzyk5xz3we7thshsoh5jbgn7jy",
         "contract/valory/balance_tracker/0.1.0": "bafybeigitc6tsfopaib7vtk5gsvozbnwiuwryvpweqj6kjrmijtnvzqkzi",
-        "contract/valory/service_registry/0.1.0": "bafybeigpmustia2afw3honksp6px2kjd4a5d7jl7es6tji53uavjvhdeki",
-        "contract/valory/gnosis_safe_proxy_factory/0.1.0": "bafybeid33okhawyrjq3khiaqeufdg46ypayquefhj5ckfabo7wtvw4yadu",
-        "contract/valory/gnosis_safe/0.1.0": "bafybeih3uparznz427cy7djs5eo5lqaww3fcasbkrnckerkad6jslipgge",
         "contract/valory/multisend/0.1.0": "bafybeihx7c3xj6c5v4tgvu3ipnj7seyc4dkmovoyzu4isgbwdrhj2oo6uq",
         "contract/valory/mech_marketplace/0.1.0": "bafybeiapnlzimazvfivnrxxiy4syd77xqeswn5un24isa7m3562ozqsgn4",
         "contract/valory/olas_mech/0.1.0": "bafybeibraj4uypb5pafavzrbeyfdlnbcchm5vefpuev5dhiypqb7av25om",
-        "contract/valory/erc20/0.1.0": "bafybeifo4zp42fjq2ytcknsfthvc5ztijsutjw5p5txi3tdwk2xtywjm3i",
+        "contract/valory/gnosis_safe_proxy_factory/0.1.0": "bafybeieonbkuskzg2rwgbqwmouusnfdd4npow2pzasimetiebo3jhwjh7m",
+        "contract/valory/service_registry/0.1.0": "bafybeigefenwg3lj4nvwc3cs5zxyhv4nvwnwbw5x7afwyijkjbbgbf2l7e",
+        "contract/valory/gnosis_safe/0.1.0": "bafybeice337zvg3ol4cwpw2iikxcukmthwmw32ytwtdnkcju222qfc323y",
+        "contract/valory/erc20/0.1.0": "bafybeifq6zn2p5nafi6bmtf4xo3ctgymazr2udtlwyiwjf5g5mpndsthfy",
         "connection/valory/websocket_client/0.1.0": "bafybeid4cnbjpmzcsw3usg7umufgqyod2u3xfw5uso3vukt3n5hfuxvdea",
         "connection/valory/http_client/0.23.0": "bafybeihel6sg2yayxu7lqygaswdgciaxpqrgsbl5rwx74c6znu5qz2edd4",
-        "connection/valory/abci/0.1.0": "bafybeifiqevht22tvlwxcuupqq7gpmlqomwzd6gjdbptxc3fovrpwvyfmm",
-        "connection/valory/ipfs/0.1.0": "bafybeifcwxo3l56mlcucpdaoqhiczzkbyemrgtffoxzsqx67g567jcfeya",
         "connection/valory/ledger/0.19.0": "bafybeid5uwx4uqxkiibw6kazr7my5mk5kcqg2dx2owtcf7kcpbs2jrns2e",
         "connection/valory/p2p_libp2p_client/0.1.0": "bafybeielj3jso3wvrarp5n5rq7llpw4vgxybqiyensgjalb5ubfiawwhhu",
         "connection/valory/http_server/0.22.0": "bafybeid4oqsfkqo36lryoecymjnq4whme3tgupqfq6m4l7lbr5r4yxtswu",
+        "connection/valory/abci/0.1.0": "bafybeigjmetusztbj3ikgsimj55rc3nn6m2j6ns6ciew5twjtgip2axdme",
+        "connection/valory/ipfs/0.1.0": "bafybeib44s5rdz5xwzwuncm2gwo6zvqsy6yefvbf5znmjc4mw3goql23ha",
         "skill/valory/websocket_client/0.1.0": "bafybeie63j65ffblz6g6oiaynjpz4ae5mgyjz2w6o5ovqitzdbnvqzlhzu",
-        "skill/valory/transaction_settlement_abci/0.1.0": "bafybeig5qnrsryhean563pxhrfkcfs6qssi5edzm656oieupvcci7ftbvy",
-        "skill/valory/termination_abci/0.1.0": "bafybeic7eeg5aw322ahs6ukvivwnzusqkejmmdep7raurhtn4r5wgv534u",
-        "skill/valory/abstract_round_abci/0.1.0": "bafybeia4gzaxgykfkcerb3cublmei7bmozqn36tzfbnmzkrg2xdrrjfnfa",
-        "skill/valory/reset_pause_abci/0.1.0": "bafybeicwt35bzw43ujjrbztjloeg424zbqxsro5vufsnhfmmvxu4h3dpva",
-        "skill/valory/registration_abci/0.1.0": "bafybeicaxkyzvqokzne42b2ijgvlnjshowdijakrantdhnvfagbgp4lyym",
-        "skill/valory/abstract_abci/0.1.0": "bafybeie2f2une2ahfstcogll3wyfmyldy4pdzmmpdy3xibq7qvnj4giqfa",
         "skill/valory/contract_subscription/0.1.0": "bafybeibtcbtgm5ptzn6srfts3lxts5722sygmkypcknv5ocmydqwcvgeem",
-        "skill/valory/delivery_rate_abci/0.1.0": "bafybeicqxj462lbkfhuj6izpw7gjn6hehfztzxazjaxiexlcgyh4fyqo3a",
-        "skill/valory/mech_abci/0.1.0": "bafybeier3s5cgexg4czqa22lzplnla65z4sa3hfnttarez3hxi5xvxffpm",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeiadi3ncl5nxrwxxa2zwinvtbscyhnowkseswcu7lpxlc7p3fau7mq",
-        "skill/valory/task_execution/0.1.0": "bafybeigculcy5zfp2yacduwmvpgs2hbjtiu2k3oyody7mw7psl3a4thneq"
+        "skill/valory/abstract_abci/0.1.0": "bafybeict6h3wfmddpvam5gmmanqzuokup6ppoev3t4j5uyl7xxahjaols4",
+        "skill/valory/abstract_round_abci/0.1.0": "bafybeihygetmlgnhawrbyswvpvv3wpztr2hlhxkljmohp4r7qcmvglpwdq",
+        "skill/valory/transaction_settlement_abci/0.1.0": "bafybeiajyrszyyo6z4lxogutv4ougiaeoxak6xkq5gtrbey32gbgnirznq",
+        "skill/valory/registration_abci/0.1.0": "bafybeif3gpewppz5wr5mmgyvaowsamjufyons3oif7cb4x5ubvvfb6rtda",
+        "skill/valory/reset_pause_abci/0.1.0": "bafybeidcnf77bc3o7pssa5zesilpbm4ley2k45taii5j5rrvvty7uhu3lq",
+        "skill/valory/termination_abci/0.1.0": "bafybeia33hlouukdpwaxctunauudv5gpfdxndimra7yqiof4a3skcwdqkq",
+        "skill/valory/delivery_rate_abci/0.1.0": "bafybeifpoqkcdwpyq4lijumyt3gzj3vs3pfxxm4xefqxagd4b5pg6x3vty",
+        "skill/valory/mech_abci/0.1.0": "bafybeifkutq4zmcd7xfdyoisqy74zfko6obxhvkfscqkeuymsnorq7ydb4",
+        "skill/valory/task_execution/0.1.0": "bafybeih6dsrn2v4ftizcl2tdpp6ftx2d4hpfqvqascfx3ggmufczhofyty",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeid3bjxx6a4p7fqryk4tveu7epy4oh7aw52ieaairojxmpu5xlb7qe"
     }
 }

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -1,7 +1,7 @@
 {
     "dev": {
-        "agent/valory/mech_server/0.1.0": "bafybeifasnqv5dah25pgqjr3cslspg2pah6kgzoyvju7kxzbfspv67e3o4",
-        "service/valory/mech_server/0.1.0": "bafybeihnyvt5canpxmvyg4hkagrgzpi64lao7at46kswajpumcc5v3rtta"
+        "agent/valory/mech_server/0.1.0": "bafybeidgekjvls4zxzvpqnzcgawpu5whi5va4yvwpzsqinahdoaefw3hbi",
+        "service/valory/mech_server/0.1.0": "bafybeicf53d2zqehy7ynb476dhoseb5mqym4egoe76jbpbabkkwn2pp5zy"
     },
     "third_party": {
         "protocol/valory/acn_data_share/0.1.0": "bafybeieqisfr6lhaaesq37lk7vyaxza2h6nucshksgyo2djqfyf2saqo4i",
@@ -17,31 +17,31 @@
         "contract/valory/complementary_service_metadata/0.1.0": "bafybeibjk5gdgc54wx5bz4fl2666urmfj6mx3ocqxyumqpj7wq5fdg4diu",
         "contract/valory/hash_checkpoint/0.1.0": "bafybeihpds2kkr5okehfa4ohbalur3fihzyk5xz3we7thshsoh5jbgn7jy",
         "contract/valory/balance_tracker/0.1.0": "bafybeigitc6tsfopaib7vtk5gsvozbnwiuwryvpweqj6kjrmijtnvzqkzi",
-        "contract/valory/service_registry/0.1.0": "bafybeidgaofqjehczv4seqj6hvyxuctsbksnlkbp4ezoq7rgogmtmudyba",
-        "contract/valory/gnosis_safe_proxy_factory/0.1.0": "bafybeid3ximsucl6zzykjwn45sx4zw4633ytlbm6k47fk2rclxefltuawq",
-        "contract/valory/gnosis_safe/0.1.0": "bafybeih4ktqfd4jkprpn7i5mebnsnddh65jhgx4yz5tkkpf2kvful3wkoa",
+        "contract/valory/service_registry/0.1.0": "bafybeigpmustia2afw3honksp6px2kjd4a5d7jl7es6tji53uavjvhdeki",
+        "contract/valory/gnosis_safe_proxy_factory/0.1.0": "bafybeid33okhawyrjq3khiaqeufdg46ypayquefhj5ckfabo7wtvw4yadu",
+        "contract/valory/gnosis_safe/0.1.0": "bafybeih3uparznz427cy7djs5eo5lqaww3fcasbkrnckerkad6jslipgge",
         "contract/valory/multisend/0.1.0": "bafybeihx7c3xj6c5v4tgvu3ipnj7seyc4dkmovoyzu4isgbwdrhj2oo6uq",
         "contract/valory/mech_marketplace/0.1.0": "bafybeiapnlzimazvfivnrxxiy4syd77xqeswn5un24isa7m3562ozqsgn4",
         "contract/valory/olas_mech/0.1.0": "bafybeibraj4uypb5pafavzrbeyfdlnbcchm5vefpuev5dhiypqb7av25om",
-        "contract/valory/erc20/0.1.0": "bafybeig6qnl2ecljaczcd6e4hwsm7aw7655oyj23dyxtyvc5ayu3kzcl5e",
+        "contract/valory/erc20/0.1.0": "bafybeifo4zp42fjq2ytcknsfthvc5ztijsutjw5p5txi3tdwk2xtywjm3i",
         "connection/valory/websocket_client/0.1.0": "bafybeid4cnbjpmzcsw3usg7umufgqyod2u3xfw5uso3vukt3n5hfuxvdea",
         "connection/valory/http_client/0.23.0": "bafybeihel6sg2yayxu7lqygaswdgciaxpqrgsbl5rwx74c6znu5qz2edd4",
-        "connection/valory/abci/0.1.0": "bafybeia2fpbej2tdklgprvuvgtjwswlluzdkbfbj2tbvguzavexn3ulpai",
+        "connection/valory/abci/0.1.0": "bafybeifiqevht22tvlwxcuupqq7gpmlqomwzd6gjdbptxc3fovrpwvyfmm",
         "connection/valory/ipfs/0.1.0": "bafybeifcwxo3l56mlcucpdaoqhiczzkbyemrgtffoxzsqx67g567jcfeya",
         "connection/valory/ledger/0.19.0": "bafybeid5uwx4uqxkiibw6kazr7my5mk5kcqg2dx2owtcf7kcpbs2jrns2e",
         "connection/valory/p2p_libp2p_client/0.1.0": "bafybeielj3jso3wvrarp5n5rq7llpw4vgxybqiyensgjalb5ubfiawwhhu",
         "connection/valory/http_server/0.22.0": "bafybeid4oqsfkqo36lryoecymjnq4whme3tgupqfq6m4l7lbr5r4yxtswu",
         "skill/valory/websocket_client/0.1.0": "bafybeie63j65ffblz6g6oiaynjpz4ae5mgyjz2w6o5ovqitzdbnvqzlhzu",
-        "skill/valory/transaction_settlement_abci/0.1.0": "bafybeie2lj22nrliky4xuobpihpaglhju6x4oaq56765ueoxgcqgjahb34",
-        "skill/valory/termination_abci/0.1.0": "bafybeigmozjv5tm2nzoj4kwtzo433m75su3mkmk5ulgcasjpomi3b6uaom",
-        "skill/valory/abstract_round_abci/0.1.0": "bafybeiamwgraw77dsawauz7fxabiqsa344vrieiljw37eufbl55ijpdmha",
-        "skill/valory/reset_pause_abci/0.1.0": "bafybeiepj7ek22rgw2blhu3s423xu4u7hjcptluvkcduhvweyrahbzsfkq",
-        "skill/valory/registration_abci/0.1.0": "bafybeiajjkzebtdlvnsjhhqojgomf2cy6ciridpx3purwbj7frfble5spm",
-        "skill/valory/abstract_abci/0.1.0": "bafybeidf6cjcl4ra7ryj3xm74x7o7jfpg6wvgutn7lcijcajcdvh33657q",
+        "skill/valory/transaction_settlement_abci/0.1.0": "bafybeig5qnrsryhean563pxhrfkcfs6qssi5edzm656oieupvcci7ftbvy",
+        "skill/valory/termination_abci/0.1.0": "bafybeic7eeg5aw322ahs6ukvivwnzusqkejmmdep7raurhtn4r5wgv534u",
+        "skill/valory/abstract_round_abci/0.1.0": "bafybeia4gzaxgykfkcerb3cublmei7bmozqn36tzfbnmzkrg2xdrrjfnfa",
+        "skill/valory/reset_pause_abci/0.1.0": "bafybeicwt35bzw43ujjrbztjloeg424zbqxsro5vufsnhfmmvxu4h3dpva",
+        "skill/valory/registration_abci/0.1.0": "bafybeicaxkyzvqokzne42b2ijgvlnjshowdijakrantdhnvfagbgp4lyym",
+        "skill/valory/abstract_abci/0.1.0": "bafybeie2f2une2ahfstcogll3wyfmyldy4pdzmmpdy3xibq7qvnj4giqfa",
         "skill/valory/contract_subscription/0.1.0": "bafybeibtcbtgm5ptzn6srfts3lxts5722sygmkypcknv5ocmydqwcvgeem",
-        "skill/valory/delivery_rate_abci/0.1.0": "bafybeifjvvapcdzfdq3ooivjw42hwbvbdmcrrqewsjanzrdrh4ekiayvdu",
-        "skill/valory/mech_abci/0.1.0": "bafybeieq54nv4tsnxgxnn3qqwah6usxmjgfdatkxhxsr2qlcb3djwx5xii",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeida7puuegik7n5um3rx4kqy3s7npr6ebe7tnxcpcunfkk7ogo65xe",
-        "skill/valory/task_execution/0.1.0": "bafybeidazic7knv3k2zoyyxahgvut62nddquijijix26sv6rxctlhopigi"
+        "skill/valory/delivery_rate_abci/0.1.0": "bafybeicqxj462lbkfhuj6izpw7gjn6hehfztzxazjaxiexlcgyh4fyqo3a",
+        "skill/valory/mech_abci/0.1.0": "bafybeier3s5cgexg4czqa22lzplnla65z4sa3hfnttarez3hxi5xvxffpm",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeiadi3ncl5nxrwxxa2zwinvtbscyhnowkseswcu7lpxlc7p3fau7mq",
+        "skill/valory/task_execution/0.1.0": "bafybeigculcy5zfp2yacduwmvpgs2hbjtiu2k3oyody7mw7psl3a4thneq"
     }
 }

--- a/packages/valory/agents/mech_server/aea-config.yaml
+++ b/packages/valory/agents/mech_server/aea-config.yaml
@@ -7,7 +7,7 @@ aea_version: '>=2.0.0, <3.0.0'
 fingerprint: {}
 fingerprint_ignore_patterns: []
 connections:
-- valory/abci:0.1.0:bafybeia2fpbej2tdklgprvuvgtjwswlluzdkbfbj2tbvguzavexn3ulpai
+- valory/abci:0.1.0:bafybeifiqevht22tvlwxcuupqq7gpmlqomwzd6gjdbptxc3fovrpwvyfmm
 - valory/http_client:0.23.0:bafybeihel6sg2yayxu7lqygaswdgciaxpqrgsbl5rwx74c6znu5qz2edd4
 - valory/http_server:0.22.0:bafybeid4oqsfkqo36lryoecymjnq4whme3tgupqfq6m4l7lbr5r4yxtswu
 - valory/ipfs:0.1.0:bafybeifcwxo3l56mlcucpdaoqhiczzkbyemrgtffoxzsqx67g567jcfeya
@@ -17,14 +17,14 @@ connections:
 contracts:
 - valory/olas_mech:0.1.0:bafybeibraj4uypb5pafavzrbeyfdlnbcchm5vefpuev5dhiypqb7av25om
 - valory/complementary_service_metadata:0.1.0:bafybeibjk5gdgc54wx5bz4fl2666urmfj6mx3ocqxyumqpj7wq5fdg4diu
-- valory/gnosis_safe:0.1.0:bafybeih4ktqfd4jkprpn7i5mebnsnddh65jhgx4yz5tkkpf2kvful3wkoa
-- valory/gnosis_safe_proxy_factory:0.1.0:bafybeid3ximsucl6zzykjwn45sx4zw4633ytlbm6k47fk2rclxefltuawq
+- valory/gnosis_safe:0.1.0:bafybeih3uparznz427cy7djs5eo5lqaww3fcasbkrnckerkad6jslipgge
+- valory/gnosis_safe_proxy_factory:0.1.0:bafybeid33okhawyrjq3khiaqeufdg46ypayquefhj5ckfabo7wtvw4yadu
 - valory/hash_checkpoint:0.1.0:bafybeihpds2kkr5okehfa4ohbalur3fihzyk5xz3we7thshsoh5jbgn7jy
 - valory/multisend:0.1.0:bafybeihx7c3xj6c5v4tgvu3ipnj7seyc4dkmovoyzu4isgbwdrhj2oo6uq
-- valory/service_registry:0.1.0:bafybeidgaofqjehczv4seqj6hvyxuctsbksnlkbp4ezoq7rgogmtmudyba
+- valory/service_registry:0.1.0:bafybeigpmustia2afw3honksp6px2kjd4a5d7jl7es6tji53uavjvhdeki
 - valory/mech_marketplace:0.1.0:bafybeiapnlzimazvfivnrxxiy4syd77xqeswn5un24isa7m3562ozqsgn4
 - valory/balance_tracker:0.1.0:bafybeigitc6tsfopaib7vtk5gsvozbnwiuwryvpweqj6kjrmijtnvzqkzi
-- valory/erc20:0.1.0:bafybeig6qnl2ecljaczcd6e4hwsm7aw7655oyj23dyxtyvc5ayu3kzcl5e
+- valory/erc20:0.1.0:bafybeifo4zp42fjq2ytcknsfthvc5ztijsutjw5p5txi3tdwk2xtywjm3i
 protocols:
 - open_aea/signing:1.0.0:bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye
 - valory/abci:0.1.0:bafybeiak4pwac3pwjtd7weskxdhkrcopckr32vtazfbuteu6yqjkwarpte
@@ -37,17 +37,17 @@ protocols:
 - valory/tendermint:0.1.0:bafybeihzb7e32f7jcrzvubilqaxzmyk7ea6ss3pg3tliatdlrr76qeknyq
 - valory/websocket_client:0.1.0:bafybeig6omutaqt5rbvidju4zc7pwwdi6tkagwu3dwiirosadyoo534v3q
 skills:
-- valory/abstract_abci:0.1.0:bafybeidf6cjcl4ra7ryj3xm74x7o7jfpg6wvgutn7lcijcajcdvh33657q
-- valory/abstract_round_abci:0.1.0:bafybeiamwgraw77dsawauz7fxabiqsa344vrieiljw37eufbl55ijpdmha
+- valory/abstract_abci:0.1.0:bafybeie2f2une2ahfstcogll3wyfmyldy4pdzmmpdy3xibq7qvnj4giqfa
+- valory/abstract_round_abci:0.1.0:bafybeia4gzaxgykfkcerb3cublmei7bmozqn36tzfbnmzkrg2xdrrjfnfa
 - valory/contract_subscription:0.1.0:bafybeibtcbtgm5ptzn6srfts3lxts5722sygmkypcknv5ocmydqwcvgeem
-- valory/mech_abci:0.1.0:bafybeieq54nv4tsnxgxnn3qqwah6usxmjgfdatkxhxsr2qlcb3djwx5xii
-- valory/registration_abci:0.1.0:bafybeiajjkzebtdlvnsjhhqojgomf2cy6ciridpx3purwbj7frfble5spm
-- valory/reset_pause_abci:0.1.0:bafybeiepj7ek22rgw2blhu3s423xu4u7hjcptluvkcduhvweyrahbzsfkq
-- valory/delivery_rate_abci:0.1.0:bafybeifjvvapcdzfdq3ooivjw42hwbvbdmcrrqewsjanzrdrh4ekiayvdu
-- valory/task_execution:0.1.0:bafybeidazic7knv3k2zoyyxahgvut62nddquijijix26sv6rxctlhopigi
-- valory/task_submission_abci:0.1.0:bafybeida7puuegik7n5um3rx4kqy3s7npr6ebe7tnxcpcunfkk7ogo65xe
-- valory/termination_abci:0.1.0:bafybeigmozjv5tm2nzoj4kwtzo433m75su3mkmk5ulgcasjpomi3b6uaom
-- valory/transaction_settlement_abci:0.1.0:bafybeie2lj22nrliky4xuobpihpaglhju6x4oaq56765ueoxgcqgjahb34
+- valory/mech_abci:0.1.0:bafybeier3s5cgexg4czqa22lzplnla65z4sa3hfnttarez3hxi5xvxffpm
+- valory/registration_abci:0.1.0:bafybeicaxkyzvqokzne42b2ijgvlnjshowdijakrantdhnvfagbgp4lyym
+- valory/reset_pause_abci:0.1.0:bafybeicwt35bzw43ujjrbztjloeg424zbqxsro5vufsnhfmmvxu4h3dpva
+- valory/delivery_rate_abci:0.1.0:bafybeicqxj462lbkfhuj6izpw7gjn6hehfztzxazjaxiexlcgyh4fyqo3a
+- valory/task_execution:0.1.0:bafybeigculcy5zfp2yacduwmvpgs2hbjtiu2k3oyody7mw7psl3a4thneq
+- valory/task_submission_abci:0.1.0:bafybeiadi3ncl5nxrwxxa2zwinvtbscyhnowkseswcu7lpxlc7p3fau7mq
+- valory/termination_abci:0.1.0:bafybeic7eeg5aw322ahs6ukvivwnzusqkejmmdep7raurhtn4r5wgv534u
+- valory/transaction_settlement_abci:0.1.0:bafybeig5qnrsryhean563pxhrfkcfs6qssi5edzm656oieupvcci7ftbvy
 - valory/websocket_client:0.1.0:bafybeie63j65ffblz6g6oiaynjpz4ae5mgyjz2w6o5ovqitzdbnvqzlhzu
 default_ledger: ethereum
 required_ledgers:

--- a/packages/valory/agents/mech_server/aea-config.yaml
+++ b/packages/valory/agents/mech_server/aea-config.yaml
@@ -7,24 +7,24 @@ aea_version: '>=2.0.0, <3.0.0'
 fingerprint: {}
 fingerprint_ignore_patterns: []
 connections:
-- valory/abci:0.1.0:bafybeifiqevht22tvlwxcuupqq7gpmlqomwzd6gjdbptxc3fovrpwvyfmm
+- valory/abci:0.1.0:bafybeigjmetusztbj3ikgsimj55rc3nn6m2j6ns6ciew5twjtgip2axdme
 - valory/http_client:0.23.0:bafybeihel6sg2yayxu7lqygaswdgciaxpqrgsbl5rwx74c6znu5qz2edd4
 - valory/http_server:0.22.0:bafybeid4oqsfkqo36lryoecymjnq4whme3tgupqfq6m4l7lbr5r4yxtswu
-- valory/ipfs:0.1.0:bafybeifcwxo3l56mlcucpdaoqhiczzkbyemrgtffoxzsqx67g567jcfeya
+- valory/ipfs:0.1.0:bafybeib44s5rdz5xwzwuncm2gwo6zvqsy6yefvbf5znmjc4mw3goql23ha
 - valory/ledger:0.19.0:bafybeid5uwx4uqxkiibw6kazr7my5mk5kcqg2dx2owtcf7kcpbs2jrns2e
 - valory/p2p_libp2p_client:0.1.0:bafybeielj3jso3wvrarp5n5rq7llpw4vgxybqiyensgjalb5ubfiawwhhu
 - valory/websocket_client:0.1.0:bafybeid4cnbjpmzcsw3usg7umufgqyod2u3xfw5uso3vukt3n5hfuxvdea
 contracts:
 - valory/olas_mech:0.1.0:bafybeibraj4uypb5pafavzrbeyfdlnbcchm5vefpuev5dhiypqb7av25om
 - valory/complementary_service_metadata:0.1.0:bafybeibjk5gdgc54wx5bz4fl2666urmfj6mx3ocqxyumqpj7wq5fdg4diu
-- valory/gnosis_safe:0.1.0:bafybeih3uparznz427cy7djs5eo5lqaww3fcasbkrnckerkad6jslipgge
-- valory/gnosis_safe_proxy_factory:0.1.0:bafybeid33okhawyrjq3khiaqeufdg46ypayquefhj5ckfabo7wtvw4yadu
+- valory/gnosis_safe:0.1.0:bafybeice337zvg3ol4cwpw2iikxcukmthwmw32ytwtdnkcju222qfc323y
+- valory/gnosis_safe_proxy_factory:0.1.0:bafybeieonbkuskzg2rwgbqwmouusnfdd4npow2pzasimetiebo3jhwjh7m
 - valory/hash_checkpoint:0.1.0:bafybeihpds2kkr5okehfa4ohbalur3fihzyk5xz3we7thshsoh5jbgn7jy
 - valory/multisend:0.1.0:bafybeihx7c3xj6c5v4tgvu3ipnj7seyc4dkmovoyzu4isgbwdrhj2oo6uq
-- valory/service_registry:0.1.0:bafybeigpmustia2afw3honksp6px2kjd4a5d7jl7es6tji53uavjvhdeki
+- valory/service_registry:0.1.0:bafybeigefenwg3lj4nvwc3cs5zxyhv4nvwnwbw5x7afwyijkjbbgbf2l7e
 - valory/mech_marketplace:0.1.0:bafybeiapnlzimazvfivnrxxiy4syd77xqeswn5un24isa7m3562ozqsgn4
 - valory/balance_tracker:0.1.0:bafybeigitc6tsfopaib7vtk5gsvozbnwiuwryvpweqj6kjrmijtnvzqkzi
-- valory/erc20:0.1.0:bafybeifo4zp42fjq2ytcknsfthvc5ztijsutjw5p5txi3tdwk2xtywjm3i
+- valory/erc20:0.1.0:bafybeifq6zn2p5nafi6bmtf4xo3ctgymazr2udtlwyiwjf5g5mpndsthfy
 protocols:
 - open_aea/signing:1.0.0:bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye
 - valory/abci:0.1.0:bafybeiak4pwac3pwjtd7weskxdhkrcopckr32vtazfbuteu6yqjkwarpte
@@ -37,17 +37,17 @@ protocols:
 - valory/tendermint:0.1.0:bafybeihzb7e32f7jcrzvubilqaxzmyk7ea6ss3pg3tliatdlrr76qeknyq
 - valory/websocket_client:0.1.0:bafybeig6omutaqt5rbvidju4zc7pwwdi6tkagwu3dwiirosadyoo534v3q
 skills:
-- valory/abstract_abci:0.1.0:bafybeie2f2une2ahfstcogll3wyfmyldy4pdzmmpdy3xibq7qvnj4giqfa
-- valory/abstract_round_abci:0.1.0:bafybeia4gzaxgykfkcerb3cublmei7bmozqn36tzfbnmzkrg2xdrrjfnfa
+- valory/abstract_abci:0.1.0:bafybeict6h3wfmddpvam5gmmanqzuokup6ppoev3t4j5uyl7xxahjaols4
+- valory/abstract_round_abci:0.1.0:bafybeihygetmlgnhawrbyswvpvv3wpztr2hlhxkljmohp4r7qcmvglpwdq
 - valory/contract_subscription:0.1.0:bafybeibtcbtgm5ptzn6srfts3lxts5722sygmkypcknv5ocmydqwcvgeem
-- valory/mech_abci:0.1.0:bafybeier3s5cgexg4czqa22lzplnla65z4sa3hfnttarez3hxi5xvxffpm
-- valory/registration_abci:0.1.0:bafybeicaxkyzvqokzne42b2ijgvlnjshowdijakrantdhnvfagbgp4lyym
-- valory/reset_pause_abci:0.1.0:bafybeicwt35bzw43ujjrbztjloeg424zbqxsro5vufsnhfmmvxu4h3dpva
-- valory/delivery_rate_abci:0.1.0:bafybeicqxj462lbkfhuj6izpw7gjn6hehfztzxazjaxiexlcgyh4fyqo3a
-- valory/task_execution:0.1.0:bafybeigculcy5zfp2yacduwmvpgs2hbjtiu2k3oyody7mw7psl3a4thneq
-- valory/task_submission_abci:0.1.0:bafybeiadi3ncl5nxrwxxa2zwinvtbscyhnowkseswcu7lpxlc7p3fau7mq
-- valory/termination_abci:0.1.0:bafybeic7eeg5aw322ahs6ukvivwnzusqkejmmdep7raurhtn4r5wgv534u
-- valory/transaction_settlement_abci:0.1.0:bafybeig5qnrsryhean563pxhrfkcfs6qssi5edzm656oieupvcci7ftbvy
+- valory/mech_abci:0.1.0:bafybeifkutq4zmcd7xfdyoisqy74zfko6obxhvkfscqkeuymsnorq7ydb4
+- valory/registration_abci:0.1.0:bafybeif3gpewppz5wr5mmgyvaowsamjufyons3oif7cb4x5ubvvfb6rtda
+- valory/reset_pause_abci:0.1.0:bafybeidcnf77bc3o7pssa5zesilpbm4ley2k45taii5j5rrvvty7uhu3lq
+- valory/delivery_rate_abci:0.1.0:bafybeifpoqkcdwpyq4lijumyt3gzj3vs3pfxxm4xefqxagd4b5pg6x3vty
+- valory/task_execution:0.1.0:bafybeih6dsrn2v4ftizcl2tdpp6ftx2d4hpfqvqascfx3ggmufczhofyty
+- valory/task_submission_abci:0.1.0:bafybeid3bjxx6a4p7fqryk4tveu7epy4oh7aw52ieaairojxmpu5xlb7qe
+- valory/termination_abci:0.1.0:bafybeia33hlouukdpwaxctunauudv5gpfdxndimra7yqiof4a3skcwdqkq
+- valory/transaction_settlement_abci:0.1.0:bafybeiajyrszyyo6z4lxogutv4ougiaeoxak6xkq5gtrbey32gbgnirznq
 - valory/websocket_client:0.1.0:bafybeie63j65ffblz6g6oiaynjpz4ae5mgyjz2w6o5ovqitzdbnvqzlhzu
 default_ledger: ethereum
 required_ledgers:

--- a/packages/valory/services/mech_server/service.yaml
+++ b/packages/valory/services/mech_server/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeifm54s6e37mjdcjtfubkyiyusykxbyza5m3njlquokq2zupfottzm
 fingerprint_ignore_patterns: []
-agent: valory/mech_server:0.1.0:bafybeifasnqv5dah25pgqjr3cslspg2pah6kgzoyvju7kxzbfspv67e3o4
+agent: valory/mech_server:0.1.0:bafybeidgekjvls4zxzvpqnzcgawpu5whi5va4yvwpzsqinahdoaefw3hbi
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/services/mech_server/service.yaml
+++ b/packages/valory/services/mech_server/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeifm54s6e37mjdcjtfubkyiyusykxbyza5m3njlquokq2zupfottzm
 fingerprint_ignore_patterns: []
-agent: valory/mech_server:0.1.0:bafybeidgekjvls4zxzvpqnzcgawpu5whi5va4yvwpzsqinahdoaefw3hbi
+agent: valory/mech_server:0.1.0:bafybeibtep6cwo3vg77vrnowilksnuq5lsf5mclzji3hkuw6l26sl7ndrm
 number_of_agents: 4
 deployment:
   agent:

--- a/poetry.lock
+++ b/poetry.lock
@@ -2,14 +2,14 @@
 
 [[package]]
 name = "aea-helpers"
-version = "0.21.16rc1"
+version = "0.21.16"
 description = "CLI helpers for CI and dependency management in AEA-based projects."
 optional = false
 python-versions = "*"
 groups = ["main"]
 files = [
-    {file = "aea_helpers-0.21.16rc1-py3-none-any.whl", hash = "sha256:57ad96e25a322be79bf432a92b6046e9fae50742f32524bddcfe438035552fdb"},
-    {file = "aea_helpers-0.21.16rc1.tar.gz", hash = "sha256:889cb88eac26b833b249d8743207eb69192421eed83fc69991529b06ae053252"},
+    {file = "aea_helpers-0.21.16-py3-none-any.whl", hash = "sha256:cf61403295cd42d1143b03fbdf1b3dd1f984066ca9dbf25e8ae45c969a79c4c2"},
+    {file = "aea_helpers-0.21.16.tar.gz", hash = "sha256:069e1a209bdb350335cf39c52bab7140d6688ae8fd0dcc9a36c27b1d6dc4829c"},
 ]
 
 [package.dependencies]
@@ -3112,14 +3112,14 @@ open-aea-ledger-ethereum = ">=2.1.0,<2.2.0"
 
 [[package]]
 name = "open-aea-test-autonomy"
-version = "0.21.16rc1"
+version = "0.21.16"
 description = "Plugin containing test tools for open-autonomy packages."
 optional = false
 python-versions = "*"
 groups = ["main"]
 files = [
-    {file = "open_aea_test_autonomy-0.21.16rc1-py3-none-any.whl", hash = "sha256:e473c86a40e857bd8f41873ba951d76767071cfd80038c1ed441edf0a8dfbb0e"},
-    {file = "open_aea_test_autonomy-0.21.16rc1.tar.gz", hash = "sha256:1f56fe14a48e1dc53f11f0becbbdb631e3623f6b27048748db931d895f23896c"},
+    {file = "open_aea_test_autonomy-0.21.16-py3-none-any.whl", hash = "sha256:c646c8bf75a166d0acd65c1cdc6ce2464177b9a0a1ff1835e1a6aa0be7d464f7"},
+    {file = "open_aea_test_autonomy-0.21.16.tar.gz", hash = "sha256:ede9075beac9640b9073efdba219c4c45f54f470398b1b69892575cb882fed56"},
 ]
 
 [package.dependencies]
@@ -3130,14 +3130,14 @@ pytest = "8.4.2"
 
 [[package]]
 name = "open-autonomy"
-version = "0.21.16rc1"
+version = "0.21.16"
 description = "A framework for the creation of autonomous agent services."
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "open_autonomy-0.21.16rc1-py3-none-any.whl", hash = "sha256:1f7b247210e162d9d77602905ddda393f35e2cc75a6626ea25e815a72c1beb65"},
-    {file = "open_autonomy-0.21.16rc1.tar.gz", hash = "sha256:a179fcb0e84467bff336fe3416321b2604c894192fe51b28e1ae8ae8d5a9335f"},
+    {file = "open_autonomy-0.21.16-py3-none-any.whl", hash = "sha256:0a5b9a65997a20a2bf979f50a53f25f05b49e0c3162d0d8a4115ade60fa27286"},
+    {file = "open_autonomy-0.21.16.tar.gz", hash = "sha256:d7c7cea3cd8f4da492aa94e8263aedc26618194aad9d2a0efb80caf6b963ed98"},
 ]
 
 [package.dependencies]
@@ -5493,4 +5493,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.15"
-content-hash = "1af3703112c7428edcfd34d0ff0b937fee6339e90538ae4acce0e61f641ef1c7"
+content-hash = "c06c11f983388e10a3dd82163e129843e5660e766bd9d1d080a8a310327b621e"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2,19 +2,21 @@
 
 [[package]]
 name = "aea-helpers"
-version = "0.21.15"
+version = "0.21.16rc1"
 description = "CLI helpers for CI and dependency management in AEA-based projects."
 optional = false
 python-versions = "*"
 groups = ["main"]
 files = [
-    {file = "aea_helpers-0.21.15-py3-none-any.whl", hash = "sha256:71b86792c96ae23d52a18f3866f97014c6d56c1ca0c4091e46539085eef9ec82"},
-    {file = "aea_helpers-0.21.15.tar.gz", hash = "sha256:99c88b24e959ec82db19ea789391db83517e72ad158addd2f5e0a603ae2d1f21"},
+    {file = "aea_helpers-0.21.16rc1-py3-none-any.whl", hash = "sha256:57ad96e25a322be79bf432a92b6046e9fae50742f32524bddcfe438035552fdb"},
+    {file = "aea_helpers-0.21.16rc1.tar.gz", hash = "sha256:889cb88eac26b833b249d8743207eb69192421eed83fc69991529b06ae053252"},
 ]
 
 [package.dependencies]
 click = ">=8.1.0,<9"
 open-autonomy = ">=0.21.0,<0.22.0"
+python-dotenv = ">=0.14.5,<2"
+PyYAML = ">=6.0,<7"
 requests = ">=2.28.0,<3"
 toml = ">=0.10,<1"
 
@@ -3110,14 +3112,14 @@ open-aea-ledger-ethereum = ">=2.1.0,<2.2.0"
 
 [[package]]
 name = "open-aea-test-autonomy"
-version = "0.21.15"
+version = "0.21.16rc1"
 description = "Plugin containing test tools for open-autonomy packages."
 optional = false
 python-versions = "*"
 groups = ["main"]
 files = [
-    {file = "open_aea_test_autonomy-0.21.15-py3-none-any.whl", hash = "sha256:cead677c56921457b80572d33da7a8bfea9908539d206f516bdf6578e9fa203b"},
-    {file = "open_aea_test_autonomy-0.21.15.tar.gz", hash = "sha256:08f08e68442781b3208f4accba8585c069fd95facf75e7aab274eabf19d7484a"},
+    {file = "open_aea_test_autonomy-0.21.16rc1-py3-none-any.whl", hash = "sha256:e473c86a40e857bd8f41873ba951d76767071cfd80038c1ed441edf0a8dfbb0e"},
+    {file = "open_aea_test_autonomy-0.21.16rc1.tar.gz", hash = "sha256:1f56fe14a48e1dc53f11f0becbbdb631e3623f6b27048748db931d895f23896c"},
 ]
 
 [package.dependencies]
@@ -3128,14 +3130,14 @@ pytest = "8.4.2"
 
 [[package]]
 name = "open-autonomy"
-version = "0.21.15"
+version = "0.21.16rc1"
 description = "A framework for the creation of autonomous agent services."
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "open_autonomy-0.21.15-py3-none-any.whl", hash = "sha256:31dc5cd756090e2c7add8efbe419d5671a9887bc9a8758aadf9bd8848ba0880c"},
-    {file = "open_autonomy-0.21.15.tar.gz", hash = "sha256:194386cfdbdac679c58b5ac1077c269dc60f92e380afe80f48dd03cc183cb740"},
+    {file = "open_autonomy-0.21.16rc1-py3-none-any.whl", hash = "sha256:1f7b247210e162d9d77602905ddda393f35e2cc75a6626ea25e815a72c1beb65"},
+    {file = "open_autonomy-0.21.16rc1.tar.gz", hash = "sha256:a179fcb0e84467bff336fe3416321b2604c894192fe51b28e1ae8ae8d5a9335f"},
 ]
 
 [package.dependencies]
@@ -5491,4 +5493,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.15"
-content-hash = "66ee9a5d7d9e874e8c1e835a21b11d35c69c480c87109696fa3ec6dfebf7de29"
+content-hash = "1af3703112c7428edcfd34d0ff0b937fee6339e90538ae4acce0e61f641ef1c7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ format = [ "sdist", "wheel",]
 
 [tool.poetry.dependencies]
 python = ">=3.10,<3.15"
-open-autonomy = "==0.21.15"
+open-autonomy = "==0.21.16rc1"
 openai = "==1.30.2"
 requests = "==2.32.5"
 py-multibase = "==1.0.3"
@@ -46,7 +46,7 @@ open-aea-ledger-ethereum = "==2.1.0"
 open-aea-ledger-cosmos = "==2.1.0"
 protobuf = "<6,>=5"
 hypothesis = "==6.21.6"
-open-aea-test-autonomy = "==0.21.15"
+open-aea-test-autonomy = "==0.21.16rc1"
 web3 = "<8,>=7.0.0"
 ipfshttpclient = "==0.8.0a2"
 open-aea-cli-ipfs = "==2.1.0"
@@ -82,7 +82,7 @@ prometheus_client = "==0.23.1"
 pebble = "==5.1.3"
 py-eth-sig-utils = "==0.4.0"
 pyyaml = "<7.0.0,>=6.0.0"
-aea-helpers = "==0.21.15"
+aea-helpers = "==0.21.16rc1"
 
 [tool.poetry.scripts]
 mech = "mtd.cli:cli"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ format = [ "sdist", "wheel",]
 
 [tool.poetry.dependencies]
 python = ">=3.10,<3.15"
-open-autonomy = "==0.21.16rc1"
+open-autonomy = "==0.21.16"
 openai = "==1.30.2"
 requests = "==2.32.5"
 py-multibase = "==1.0.3"
@@ -46,7 +46,7 @@ open-aea-ledger-ethereum = "==2.1.0"
 open-aea-ledger-cosmos = "==2.1.0"
 protobuf = "<6,>=5"
 hypothesis = "==6.21.6"
-open-aea-test-autonomy = "==0.21.16rc1"
+open-aea-test-autonomy = "==0.21.16"
 web3 = "<8,>=7.0.0"
 ipfshttpclient = "==0.8.0a2"
 open-aea-cli-ipfs = "==2.1.0"
@@ -82,7 +82,7 @@ prometheus_client = "==0.23.1"
 pebble = "==5.1.3"
 py-eth-sig-utils = "==0.4.0"
 pyyaml = "<7.0.0,>=6.0.0"
-aea-helpers = "==0.21.16rc1"
+aea-helpers = "==0.21.16"
 
 [tool.poetry.scripts]
 mech = "mtd.cli:cli"

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ deps =
 [deps-packages]
 deps =
     {[deps-tests]deps}
-    open-autonomy==0.21.15
+    open-autonomy==0.21.16rc1
     openai==1.30.2
     requests==2.32.5
     py-multibase==1.0.3
@@ -29,7 +29,7 @@ deps =
     open-aea-ledger-cosmos==2.1.0
     protobuf<6,>=5
     hypothesis==6.21.6
-    open-aea-test-autonomy==0.21.15
+    open-aea-test-autonomy==0.21.16rc1
     web3<8,>=7.0.0
     ipfshttpclient==0.8.0a2
     open-aea-cli-ipfs==2.1.0
@@ -65,7 +65,7 @@ deps =
     pebble==5.1.3
     py-eth-sig-utils==0.4.0
     pyyaml<7.0.0,>=6.0.0
-    aea-helpers==0.21.15
+    aea-helpers==0.21.16rc1
 
 [extra-deps]
 deps =
@@ -164,7 +164,7 @@ skipsdist = True
 usedevelop = True
 deps =
     protobuf>=5,<6
-    open-autonomy[all]==0.21.15
+    open-autonomy[all]==0.21.16rc1
 commands =
     autonomy init --reset --author ci --remote --ipfs --ipfs-node "/dns/registry.autonolas.tech/tcp/443/https"
     autonomy packages sync

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ deps =
 [deps-packages]
 deps =
     {[deps-tests]deps}
-    open-autonomy==0.21.16rc1
+    open-autonomy==0.21.16
     openai==1.30.2
     requests==2.32.5
     py-multibase==1.0.3
@@ -29,7 +29,7 @@ deps =
     open-aea-ledger-cosmos==2.1.0
     protobuf<6,>=5
     hypothesis==6.21.6
-    open-aea-test-autonomy==0.21.16rc1
+    open-aea-test-autonomy==0.21.16
     web3<8,>=7.0.0
     ipfshttpclient==0.8.0a2
     open-aea-cli-ipfs==2.1.0
@@ -65,7 +65,7 @@ deps =
     pebble==5.1.3
     py-eth-sig-utils==0.4.0
     pyyaml<7.0.0,>=6.0.0
-    aea-helpers==0.21.16rc1
+    aea-helpers==0.21.16
 
 [extra-deps]
 deps =
@@ -164,7 +164,7 @@ skipsdist = True
 usedevelop = True
 deps =
     protobuf>=5,<6
-    open-autonomy[all]==0.21.16rc1
+    open-autonomy[all]==0.21.16
 commands =
     autonomy init --reset --author ci --remote --ipfs --ipfs-node "/dns/registry.autonolas.tech/tcp/443/https"
     autonomy packages sync


### PR DESCRIPTION
## Summary

- Bump open-autonomy, open-aea-test-autonomy, aea-helpers to `==0.21.16rc1`
- Update third_party package hashes from OA release branch + mech PR branch
- Sync and lock packages

## Depends on

- open-autonomy v0.21.16rc1 release (published)
- [mech#420](https://github.com/valory-xyz/mech/pull/420)

🤖 Generated with [Claude Code](https://claude.com/claude-code)