### PR TITLE
ci: add All checks passed aggregate gate and make test mandatory

### DIFF
--- a/.github/workflows/common_checks.yaml
+++ b/.github/workflows/common_checks.yaml
@@ -127,7 +127,7 @@ jobs:
           gitleaks detect --report-format json --report-path leak_report -v
 
   test:
-    continue-on-error: True
+    continue-on-error: False
     needs:
       - lock_check
       - copyright_and_dependencies_check
@@ -236,3 +236,20 @@ jobs:
         run: |
           echo Building distribution
           make dist
+
+  all-checks-passed:
+    name: All checks passed
+    runs-on: ubuntu-24.04
+    if: always()
+    needs:
+      - lock_check
+      - copyright_and_dependencies_check
+      - linter_checks
+      - scan
+      - test
+      - coverage
+      - build-pip-packages
+    steps:
+      - name: Fail if any dependency failed or was cancelled
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: exit 1


### PR DESCRIPTION
## Summary
- Adds an `all-checks-passed` meta job (display name: "All checks passed") that depends on every mandatory CI job and fails if any dependency fails or is cancelled.
- Flips the `test` job from `continue-on-error: True` to `False` so test failures actually block merges.
- Sets up the single aggregate context that branch protection will require — future additions/removals of mandatory jobs only need a `needs` update in the workflow, not a branch-protection edit.

## Test plan
- [ ] CI runs green on this PR (all existing jobs pass, new `All checks passed` job reports success)
- [ ] After merge: confirm "All checks passed" appears as a selectable required context on `main`, then add it to branch protection as the sole required check.
