### PR TITLE
chore: bump version from 0.8.1 to 0.8.2

### DIFF
--- a/mtd/__init__.py
+++ b/mtd/__init__.py
@@ -19,7 +19,7 @@
 
 """Mech Tools Dev CLI."""
 
-__version__ = "0.8.1"
+__version__ = "0.8.2"
 
 from mtd.context import MtdContext, build_context, get_default_workspace
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "mech-server"
-version = "0.8.1"
+version = "0.8.2"
 description = ""
 requires-python = ">=3.10,<3.15"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -2035,7 +2035,7 @@ wheels = [
 
 [[package]]
 name = "mech-server"
-version = "0.8.1"
+version = "0.8.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- Bump `mech-server` from `0.8.1` to `0.8.2` in `pyproject.toml`, `mtd/__init__.py`, and `uv.lock`.

## Test plan
- [ ] CI passes
- [ ] After merge, tag and publish a GitHub release so `release.yaml` ships `0.8.2` to PyPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)