### PR TITLE
feat: wire FixedPriceTokenUSDC factory for Optimism + Base

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ mech run -c <chain>
 | Gnosis | ✅ | ✅ | ❌ | ✅ |
 | Base | ✅ | ✅ | ❌ | ✅ |
 | Polygon | ✅ | ✅ | ✅ | ✅ |
-| Optimism | ✅ | ✅ | ❌ | ✅ |
+| Optimism | ✅ | ✅ | ✅ | ✅ |
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ mech run -c <chain>
 | Chain | Native | OLAS Token | USDC Token | Nevermined |
 |-------|--------|------------|------------|------------|
 | Gnosis | ✅ | ✅ | ❌ | ✅ |
-| Base | ✅ | ✅ | ❌ | ✅ |
+| Base | ✅ | ✅ | ✅ | ✅ |
 | Polygon | ✅ | ✅ | ✅ | ✅ |
 | Optimism | ✅ | ✅ | ✅ | ✅ |
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -52,7 +52,7 @@ When creating a Mech, deployers can select between the following payment models:
 | Chain | Native | OLAS Token | USDC Token | Nevermined |
 |-------|--------|------------|------------|------------|
 | Gnosis | ✅ | ✅ | ❌ | ✅ |
-| Base | ✅ | ✅ | ❌ | ✅ |
+| Base | ✅ | ✅ | ✅ | ✅ |
 | Polygon | ✅ | ✅ | ✅ | ✅ |
 | Optimism | ✅ | ✅ | ✅ | ✅ |
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -54,7 +54,7 @@ When creating a Mech, deployers can select between the following payment models:
 | Gnosis | ✅ | ✅ | ❌ | ✅ |
 | Base | ✅ | ✅ | ❌ | ✅ |
 | Polygon | ✅ | ✅ | ✅ | ✅ |
-| Optimism | ✅ | ✅ | ❌ | ✅ |
+| Optimism | ✅ | ✅ | ✅ | ✅ |
 
 
 ## How the request-response flow works

--- a/mtd/deploy_mech.py
+++ b/mtd/deploy_mech.py
@@ -78,6 +78,7 @@ MECH_FACTORY_ADDRESS = {
         "0x46C0D07F55d4F9B5Eed2Fc9680B5953e5fd7b461": {
             "Native": "0xf76953444C35F1FcE2F6CA1b167173357d3F5C17",
             "Token": "0x26Ea2dC7ce1b41d0AD0E0521535655d7a94b684c",  # nosec B105
+            "TokenUSDC": "0x93111f6C267068A5d7356114D61d0f09bFD53a54",
             "Nevermined": "0x02C26437B292D86c5F4F21bbCcE0771948274f84",
         },
     },

--- a/mtd/deploy_mech.py
+++ b/mtd/deploy_mech.py
@@ -63,6 +63,7 @@ MECH_FACTORY_ADDRESS = {
         "0xf24eE42edA0fc9b33B7D41B06Ee8ccD2Ef7C5020": {
             "Native": "0x2E008211f34b25A7d7c102403c6C2C3B665a1abe",
             "Token": "0x97371B1C0cDA1D04dFc43DFb50a04645b7Bc9BEe",  # nosec B105
+            "TokenUSDC": "0x5B70A66fe68c4c86FFd724B58cc56049c70e9D3D",
             "Nevermined": "0x847bBE8b474e0820215f818858e23F5f5591855A",
         },
     },

--- a/tests/unit/test_deploy_mech.py
+++ b/tests/unit/test_deploy_mech.py
@@ -250,18 +250,16 @@ class TestMechFactoryAddress:
                 assert "Native" in factories, f"Missing Native for {chain} / {mp_addr}"
                 assert "Token" in factories, f"Missing Token for {chain} / {mp_addr}"
 
-    def test_polygon_has_token_usdc(self) -> None:
-        """Polygon supports TokenUSDC mech type."""
-        for factories in MECH_FACTORY_ADDRESS[Chain.POLYGON].values():
-            assert "TokenUSDC" in factories
-
-    def test_token_usdc_not_on_other_chains(self) -> None:
-        """Test that TokenUSDC is only on Polygon, not other chains."""
-        for chain in (Chain.GNOSIS, Chain.BASE, Chain.OPTIMISM):
+    def test_token_usdc_supported_chains(self) -> None:
+        """Polygon, Optimism and Base support the TokenUSDC mech type."""
+        for chain in (Chain.POLYGON, Chain.OPTIMISM, Chain.BASE):
             for factories in MECH_FACTORY_ADDRESS[chain].values():
-                assert (
-                    "TokenUSDC" not in factories
-                ), f"TokenUSDC should not be on {chain}"
+                assert "TokenUSDC" in factories, f"TokenUSDC missing on {chain}"
+
+    def test_token_usdc_not_on_gnosis(self) -> None:
+        """Gnosis does not offer the TokenUSDC mech type."""
+        for factories in MECH_FACTORY_ADDRESS[Chain.GNOSIS].values():
+            assert "TokenUSDC" not in factories
 
 
 class TestNeedsMechDeployment:


### PR DESCRIPTION
> **Stacked on #100** (base branch = `fix/drop-uv-prerelease-allow`). Review/merge after #100, or rebase onto `main` once #100 lands.

## What
Add the deployed `FixedPriceTokenUSDC` factories to the `deploy_mech` factory map for **Optimism** and **Base**, and flip the supported-chains tables (USDC ❌ → ✅ for both):
- Optimism factory: `0x93111f6C267068A5d7356114D61d0f09bFD53a54`
- Base factory: `0x5B70A66fe68c4c86FFd724B58cc56049c70e9D3D`

## Why
Both factories are already deployed in the respective MechMarketplaces, but were missing from `MECH_FACTORY_ADDRESS`, so `mech setup -c optimism|base` could only create Native / OLAS-Token / Nevermined mechs. This makes `MECH_TYPE=TokenUSDC` work on both (`MECH_REQUEST_PRICE` is USDC 6-decimals, e.g. `10000` = 0.01 USDC). Mirrors the existing Polygon support.

## Scope / notes
- Pure factory-map + docs change; no config/runtime changes (USDC support is purely the factory-map entry, same as Polygon).
- **Create side only** — a requester paying a USDC mech still needs a USDC `approve` to the balance tracker (native `value` is unused for token mechs).
- **Validated:** a TokenUSDC mech was created via this wiring on **Optimism** — both on a Tenderly OP fork and on **OP mainnet** (`0x650C77F49cFa69e2AC1990A6B4585C322B012D0d`, 0.01 USDC). The Base path is identical (factory deployed, same flow).

## Testing
`bandit` + the full lint group (`black-check`/`isort-check`/`flake8`/`mypy`/`pylint`/`darglint`) pass locally.