### PR TITLE
fix(deploy_mech): coerce marketplace create call data to bytes for multisend

### DIFF
--- a/mtd/deploy_mech.py
+++ b/mtd/deploy_mech.py
@@ -141,13 +141,15 @@ def deploy_mech(sftxb: EthSafeTxBuilder, service: Service) -> Tuple[str, str]:
     contract = sftxb.ledger_api.api.eth.contract(
         address=Web3.to_checksum_address(mech_marketplace_address), abi=abi
     )
-    data = contract.encode_abi(
-        "create",
-        args=[
-            service.chain_configs[service.home_chain].chain_data.token,
-            Web3.to_checksum_address(mech_factory_address),
-            mech_request_price.to_bytes(32, byteorder="big"),
-        ],
+    data = bytes.fromhex(
+        contract.encode_abi(
+            "create",
+            args=[
+                service.chain_configs[service.home_chain].chain_data.token,
+                Web3.to_checksum_address(mech_factory_address),
+                mech_request_price.to_bytes(32, byteorder="big"),
+            ],
+        )[2:]
     )
     tx_dict = {
         "to": mech_marketplace_address,

--- a/tests/unit/test_deploy_mech.py
+++ b/tests/unit/test_deploy_mech.py
@@ -44,6 +44,7 @@ def _make_mock_sftxb(
     mock_sftxb.new_tx.return_value.add.return_value.settle.return_value = mock_receipt
 
     mock_contract = MagicMock()
+    mock_contract.encode_abi.return_value = "0xdeadbeef"
     mock_sftxb.ledger_api.api.eth.contract.return_value = mock_contract
 
     mock_event = {"args": {"mech": mech_address, "serviceId": 1}}


### PR DESCRIPTION
## Problem

Under web3 v7, `contract.encode_abi(...)` returns `HexStr` (a `str` alias). `open-autonomy[all]==0.21.23` (this repo's pin) ships a strict bytes-only `multisend.encode_data` which concatenates fields directly:

```python
return operation + to + value + data_length + data   # all must be bytes
```

Dropping the encoded `create` call data straight into a `MultiSendOperation.CALL` dict at `mtd/deploy_mech.py:154` therefore crashes during `mech setup`:

```
TypeError: can't concat str to bytes
```

This is the same failure surfaced by [valory-xyz/open-autonomy#2534](https://github.com/valory-xyz/open-autonomy/pull/2534).

## Fix

Coerce the call data to bytes at the caller via `bytes.fromhex(...[2:])`, matching the canonical pattern used elsewhere in the OA ecosystem (e.g. `autonomy/chain/service.py` does this for every multisend tx-dict it builds). This keeps `encode_data` strict and avoids a permissive workaround inside open-autonomy.

## Test plan

- [ ] Run `mech setup` against an Optimism mech and confirm the marketplace `create` call lands on-chain
- [ ] No regressions on existing deployments